### PR TITLE
#5 게시물 생성 API 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,14 +23,15 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+//	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/org/jungle/code_post/common/advice/ResponseHandler.java
+++ b/src/main/java/org/jungle/code_post/common/advice/ResponseHandler.java
@@ -4,6 +4,7 @@ import org.jungle.code_post.common.dto.ApiResponseDTO;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,7 +14,8 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 public class ResponseHandler implements ResponseBodyAdvice<Object> {
     @Override
     public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
-        return true;
+
+        return MappingJackson2HttpMessageConverter.class.isAssignableFrom(converterType);
     }
 
     @Override

--- a/src/main/java/org/jungle/code_post/common/advice/ResponseHandler.java
+++ b/src/main/java/org/jungle/code_post/common/advice/ResponseHandler.java
@@ -1,0 +1,30 @@
+package org.jungle.code_post.common.advice;
+
+import org.jungle.code_post.common.dto.ApiResponseDTO;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ResponseHandler implements ResponseBodyAdvice<Object> {
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+
+        return ApiResponseDTO.builder()
+                .code(200)
+                .message("request was successful")
+                .data(body)
+                .build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/common/dto/ApiResponseDTO.java
+++ b/src/main/java/org/jungle/code_post/common/dto/ApiResponseDTO.java
@@ -1,0 +1,14 @@
+package org.jungle.code_post.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApiResponseDTO<T> {
+    private Integer code;
+    private String message;
+    private T data;
+}

--- a/src/main/java/org/jungle/code_post/common/dto/ApiResponseDTO.java
+++ b/src/main/java/org/jungle/code_post/common/dto/ApiResponseDTO.java
@@ -1,10 +1,11 @@
 package org.jungle.code_post.common.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Builder
+@Getter
+@Setter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class ApiResponseDTO<T> {

--- a/src/main/java/org/jungle/code_post/post/controller/PostController.java
+++ b/src/main/java/org/jungle/code_post/post/controller/PostController.java
@@ -1,0 +1,28 @@
+package org.jungle.code_post.post.controller;
+
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.jungle.code_post.post.dto.PostCreateRequestDTO;
+import org.jungle.code_post.post.dto.PostResponseDTO;
+import org.jungle.code_post.post.service.PostService;
+import org.jungle.code_post.post.service.PostServiceNoAuth;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/post")
+@Slf4j
+public class PostController {
+    @Autowired
+    PostService postService = new PostServiceNoAuth();
+
+    @PostMapping
+    public PostResponseDTO createPost(@RequestBody PostCreateRequestDTO requestDTO) {
+        log.debug(requestDTO.toString());
+        return PostResponseDTO.of(postService.insertPost(requestDTO.toVO()));
+    }
+
+}

--- a/src/main/java/org/jungle/code_post/post/dto/PostCreateRequestDTO.java
+++ b/src/main/java/org/jungle/code_post/post/dto/PostCreateRequestDTO.java
@@ -1,0 +1,29 @@
+package org.jungle.code_post.post.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jungle.code_post.post.entity.Post;
+
+@Getter
+@RequiredArgsConstructor
+public class PostCreateRequestDTO {
+    private final String title;
+    private final String content;
+    private final String link;
+    private final String category;
+    private final Integer score;
+    private final String author;
+    private final Integer password;
+
+    public PostVO toVO(){
+        return PostVO.builder()
+                .title(title)
+                .content(content)
+                .link(link)
+                .category(category)
+                .score(score)
+                .author(author)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/post/dto/PostCreateRequestDTO.java
+++ b/src/main/java/org/jungle/code_post/post/dto/PostCreateRequestDTO.java
@@ -1,19 +1,21 @@
 package org.jungle.code_post.post.dto;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 import org.jungle.code_post.post.entity.Post;
 
 @Getter
-@RequiredArgsConstructor
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
 public class PostCreateRequestDTO {
-    private final String title;
-    private final String content;
-    private final String link;
-    private final String category;
-    private final Integer score;
-    private final String author;
-    private final Integer password;
+    private String title;
+    private String content;
+    private String link;
+    private String category;
+    private Integer score = 0;
+    private String author;
+    private Integer password;
 
     public PostVO toVO(){
         return PostVO.builder()

--- a/src/main/java/org/jungle/code_post/post/dto/PostResponseDTO.java
+++ b/src/main/java/org/jungle/code_post/post/dto/PostResponseDTO.java
@@ -1,0 +1,35 @@
+package org.jungle.code_post.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.jungle.code_post.post.entity.Post;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class PostResponseDTO {
+    private Long id;
+    private String title;
+    private String link;
+    private String category;
+    private Integer score;
+    private String author;
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+
+    public static PostResponseDTO of(Post post) {
+        return PostResponseDTO.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .link(post.getLink())
+                .category(post.getCategory())
+                .score(post.getScore())
+                .author(post.getAuthor())
+                .created_at(post.getCreatedAt())
+                .updated_at(post.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/post/dto/PostResponseDTO.java
+++ b/src/main/java/org/jungle/code_post/post/dto/PostResponseDTO.java
@@ -20,7 +20,7 @@ public class PostResponseDTO {
     private LocalDateTime created_at;
     private LocalDateTime updated_at;
 
-    public static PostResponseDTO of(Post post) {
+    public static PostResponseDTO of(PostVO post) {
         return PostResponseDTO.builder()
                 .id(post.getId())
                 .title(post.getTitle())

--- a/src/main/java/org/jungle/code_post/post/dto/PostVO.java
+++ b/src/main/java/org/jungle/code_post/post/dto/PostVO.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jungle.code_post.post.entity.Post;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @RequiredArgsConstructor
@@ -17,7 +19,24 @@ public class PostVO {
     private final Integer score;
     private final String author;
     private final int password;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
 
+
+    public static PostVO from(Post post){
+        return PostVO.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .link(post.getLink())
+                .category(post.getCategory())
+                .score(post.getScore())
+                .author(post.getAuthor())
+                .password(post.getPassword())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
+    }
     public Post toEntity(){
         return Post.builder()
                 .id(id)

--- a/src/main/java/org/jungle/code_post/post/dto/PostVO.java
+++ b/src/main/java/org/jungle/code_post/post/dto/PostVO.java
@@ -1,0 +1,33 @@
+package org.jungle.code_post.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jungle.code_post.post.entity.Post;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class PostVO {
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final String link;
+    private final String category;
+    private final Integer score;
+    private final String author;
+    private final int password;
+
+    public Post toEntity(){
+        return Post.builder()
+                .id(id)
+                .title(title)
+                .content(content)
+                .link(link)
+                .category(category)
+                .score(score)
+                .author(author)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/post/repository/PostRepository.java
+++ b/src/main/java/org/jungle/code_post/post/repository/PostRepository.java
@@ -2,6 +2,8 @@ package org.jungle.code_post.post.repository;
 
 import org.jungle.code_post.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 }

--- a/src/main/java/org/jungle/code_post/post/service/PostService.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostService.java
@@ -1,0 +1,11 @@
+package org.jungle.code_post.post.service;
+
+import org.jungle.code_post.post.dto.PostCreateRequestDTO;
+import org.jungle.code_post.post.dto.PostResponseDTO;
+import org.jungle.code_post.post.dto.PostVO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface PostService {
+    public PostVO insertPost(PostVO postDTO);
+}

--- a/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
@@ -1,0 +1,21 @@
+package org.jungle.code_post.post.service;
+
+import org.jungle.code_post.post.dto.PostCreateRequestDTO;
+import org.jungle.code_post.post.dto.PostResponseDTO;
+import org.jungle.code_post.post.dto.PostVO;
+import org.jungle.code_post.post.repository.PostRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostServiceNoAuth implements PostService{
+
+    @Autowired
+    private PostRepository postRepository;
+
+
+    @Override
+    public PostVO insertPost(PostVO postDTO) {
+        return PostVO.from(postRepository.save(postDTO.toEntity()));
+    }
+}


### PR DESCRIPTION
> Closes #5

## 작업내용

### DTO,VO 구현
- `PostCreateRequestDTO` : 게시물 등록 요청 시 해당 객체에 저장됨
- `PostVO` : 컨트롤러 <-> 서비스 계층 간 데이터 교환 객체
- `PostResponseDTO` : 게시물 조회 시 객체의 정보를 저장하여 반환

### PostController,PostService 구현
- `PostController` : `/api/post` **POST** 매핑
- `PostService` : `insertPost` 구현

### 봉투 패턴 적용
- `ResponseHandler` : Response시 `status`와 `message`를 보내도록 구현
- `ApiResponseDTO` : 공용 응답 형식을 적용하기 위해 구현    