### PR TITLE
#7 게시물 조회 API 구현 완료

### DIFF
--- a/src/main/java/org/jungle/code_post/post/controller/PostController.java
+++ b/src/main/java/org/jungle/code_post/post/controller/PostController.java
@@ -6,10 +6,9 @@ import org.jungle.code_post.post.dto.PostResponseDTO;
 import org.jungle.code_post.post.service.PostService;
 import org.jungle.code_post.post.service.PostServiceNoAuth;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/post")
@@ -19,6 +18,10 @@ public class PostController {
     @Autowired
     PostService postService = new PostServiceNoAuth();
 
+    @GetMapping
+    public List<PostResponseDTO> findAllPost(){
+        return postService.getAllPost();
+    }
     @PostMapping
     public PostResponseDTO createPost(@RequestBody PostCreateRequestDTO requestDTO) {
         return postService.insertPost(requestDTO.toVO());

--- a/src/main/java/org/jungle/code_post/post/controller/PostController.java
+++ b/src/main/java/org/jungle/code_post/post/controller/PostController.java
@@ -18,6 +18,11 @@ public class PostController {
     @Autowired
     PostService postService = new PostServiceNoAuth();
 
+    @GetMapping("/{id}")
+    public PostResponseDTO findPost(@PathVariable Long id){
+        return postService.findPostById(id);
+    }
+
     @GetMapping
     public List<PostResponseDTO> findAllPost(){
         return postService.getAllPost();

--- a/src/main/java/org/jungle/code_post/post/controller/PostController.java
+++ b/src/main/java/org/jungle/code_post/post/controller/PostController.java
@@ -25,7 +25,7 @@ public class PostController {
 
     @GetMapping
     public List<PostResponseDTO> findAllPost(){
-        return postService.getAllPost();
+        return postService.findAllPost();
     }
     @PostMapping
     public PostResponseDTO createPost(@RequestBody PostCreateRequestDTO requestDTO) {

--- a/src/main/java/org/jungle/code_post/post/dto/PostCreateRequestDTO.java
+++ b/src/main/java/org/jungle/code_post/post/dto/PostCreateRequestDTO.java
@@ -1,7 +1,6 @@
 package org.jungle.code_post.post.dto;
 
 import lombok.*;
-import org.jungle.code_post.post.entity.Post;
 
 @Getter
 @Setter

--- a/src/main/java/org/jungle/code_post/post/service/PostService.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostService.java
@@ -8,6 +8,8 @@ import java.util.List;
 
 @Service
 public interface PostService {
+    public PostResponseDTO findPostById(Long id);
     public List<PostResponseDTO> getAllPost();
+
     public PostResponseDTO insertPost(PostVO postDTO);
 }

--- a/src/main/java/org/jungle/code_post/post/service/PostService.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostService.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Service
 public interface PostService {
     public PostResponseDTO findPostById(Long id);
-    public List<PostResponseDTO> getAllPost();
+    public List<PostResponseDTO> findAllPost();
 
     public PostResponseDTO insertPost(PostVO postDTO);
 }

--- a/src/main/java/org/jungle/code_post/post/service/PostService.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostService.java
@@ -4,7 +4,10 @@ import org.jungle.code_post.post.dto.PostResponseDTO;
 import org.jungle.code_post.post.dto.PostVO;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public interface PostService {
+    public List<PostResponseDTO> getAllPost();
     public PostResponseDTO insertPost(PostVO postDTO);
 }

--- a/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
@@ -25,7 +25,7 @@ public class PostServiceNoAuth implements PostService{
     }
 
     @Override
-    public List<PostResponseDTO> getAllPost() {
+    public List<PostResponseDTO> findAllPost() {
         return postRepository.findAll().stream()
                 .map(PostResponseDTO::of)
                 .collect(Collectors.toList());

--- a/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
@@ -1,13 +1,14 @@
 package org.jungle.code_post.post.service;
 
-import org.jungle.code_post.post.dto.PostCreateRequestDTO;
 import org.jungle.code_post.post.dto.PostResponseDTO;
 import org.jungle.code_post.post.dto.PostVO;
+import org.jungle.code_post.post.entity.Post;
 import org.jungle.code_post.post.repository.PostRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -16,6 +17,12 @@ public class PostServiceNoAuth implements PostService{
     @Autowired
     private PostRepository postRepository;
 
+
+    @Override
+    public PostResponseDTO findPostById(Long id) {
+        Optional<Post> findPost = postRepository.findById(id);
+        return PostResponseDTO.of(findPost.get());
+    }
 
     @Override
     public List<PostResponseDTO> getAllPost() {

--- a/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
@@ -7,12 +7,22 @@ import org.jungle.code_post.post.repository.PostRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 public class PostServiceNoAuth implements PostService{
 
     @Autowired
     private PostRepository postRepository;
 
+
+    @Override
+    public List<PostResponseDTO> getAllPost() {
+        return postRepository.findAll().stream()
+                .map(PostResponseDTO::of)
+                .collect(Collectors.toList());
+    }
 
     @Override
     public PostResponseDTO insertPost(PostVO postDTO) {


### PR DESCRIPTION
> Closes #7

## 작업내용
### 게시물 전체 조회 API 구현
- `PostController`: `/api/post` **GET** 매핑
- `PostService`:  모든 게시물을 조회하여 반환하는 `findAllPost` 구현

### 게시물 선택 조회 API 구현
- `PostController`: `/api/post/{id}` **GET** 매핑
- `PostService` : `id`에 해당하는 게시물을 반환하는 `findPostById` 구현
