### PR TITLE
#9 게시물 수정 API 구현 완료

### DIFF
--- a/src/main/java/org/jungle/code_post/post/controller/PostController.java
+++ b/src/main/java/org/jungle/code_post/post/controller/PostController.java
@@ -3,6 +3,7 @@ package org.jungle.code_post.post.controller;
 import lombok.extern.slf4j.Slf4j;
 import org.jungle.code_post.post.dto.PostCreateRequestDTO;
 import org.jungle.code_post.post.dto.PostResponseDTO;
+import org.jungle.code_post.post.dto.PostUpdateRequestDTO;
 import org.jungle.code_post.post.service.PostService;
 import org.jungle.code_post.post.service.PostServiceNoAuth;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,11 @@ public class PostController {
     @PostMapping
     public PostResponseDTO createPost(@RequestBody PostCreateRequestDTO requestDTO) {
         return postService.insertPost(requestDTO.toVO());
+    }
+
+    @PutMapping("/{id}")
+    public PostResponseDTO updatePost(@PathVariable Long id, @RequestBody PostUpdateRequestDTO requestDTO){
+        return postService.updatePost(id,requestDTO.toVO());
     }
 
 }

--- a/src/main/java/org/jungle/code_post/post/dto/PostUpdateRequestDTO.java
+++ b/src/main/java/org/jungle/code_post/post/dto/PostUpdateRequestDTO.java
@@ -1,0 +1,28 @@
+package org.jungle.code_post.post.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostUpdateRequestDTO {
+    private String title;
+    private String content;
+    private String link;
+    private String category;
+    private Integer score = 0;
+    private Integer password;
+
+    public PostVO toVO(){
+        return PostVO.builder()
+                .title(title)
+                .content(content)
+                .link(link)
+                .category(category)
+                .score(score)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/post/service/PostService.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostService.java
@@ -9,7 +9,10 @@ import java.util.List;
 @Service
 public interface PostService {
     public PostResponseDTO findPostById(Long id);
+
     public List<PostResponseDTO> findAllPost();
 
-    public PostResponseDTO insertPost(PostVO postDTO);
+    public PostResponseDTO insertPost(PostVO postVo);
+
+    public PostResponseDTO updatePost(Long id,PostVO postVO);
 }

--- a/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
-public class PostServiceNoAuth implements PostService{
+public class PostServiceNoAuth implements PostService {
 
     @Autowired
     private PostRepository postRepository;
@@ -32,7 +32,26 @@ public class PostServiceNoAuth implements PostService{
     }
 
     @Override
-    public PostResponseDTO insertPost(PostVO postDTO) {
-        return PostResponseDTO.of(postRepository.save(postDTO.toEntity()));
+    public PostResponseDTO insertPost(PostVO postVO) {
+        return PostResponseDTO.of(postRepository.save(postVO.toEntity()));
+    }
+
+    @Override
+    public PostResponseDTO updatePost(Long id, PostVO postVO) {
+        Optional<Post> findPost = postRepository.findById(id);
+        if (findPost.isEmpty())
+            return null;
+        Post post = findPost.get();
+
+        if (post.getPassword() != postVO.getPassword())
+            return null;
+
+        post.setTitle(postVO.getTitle());
+        post.setContent(postVO.getContent());
+        post.setLink(postVO.getLink());
+        post.setCategory(postVO.getCategory());
+        post.setScore(postVO.getScore());
+
+        return PostResponseDTO.of(postRepository.save(post));
     }
 }


### PR DESCRIPTION
> Closes #9

## 작업내용
### 게시물 수정 API 구현
- `PostController`: `/api/post/{1}` **PUT** 매핑
- `PostService`:  `id`에 해당하는 게시물을 수정하고 반환하는 `updatePost` 구현