### PR TITLE
#11 게시물 삭제 API 구현 완료

### DIFF
--- a/src/main/java/org/jungle/code_post/common/advice/ResponseHandler.java
+++ b/src/main/java/org/jungle/code_post/common/advice/ResponseHandler.java
@@ -1,14 +1,21 @@
 package org.jungle.code_post.common.advice;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.jungle.code_post.common.dto.ApiResponseDTO;
 import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 @RestControllerAdvice
 public class ResponseHandler implements ResponseBodyAdvice<Object> {
@@ -19,13 +26,13 @@ public class ResponseHandler implements ResponseBodyAdvice<Object> {
     }
 
     @Override
-    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
-                                  Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request,
-                                  ServerHttpResponse response) {
+    public ApiResponseDTO beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                             Class<? extends HttpMessageConverter<?>> selectedConverterType, ServerHttpRequest request,
+                                             ServerHttpResponse response) {
 
         return ApiResponseDTO.builder()
                 .code(200)
-                .message("request was successful")
+                .message("ok")
                 .data(body)
                 .build();
     }

--- a/src/main/java/org/jungle/code_post/common/dto/MessageResponseDTO.java
+++ b/src/main/java/org/jungle/code_post/common/dto/MessageResponseDTO.java
@@ -8,8 +8,6 @@ import lombok.*;
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
-public class ApiResponseDTO<T> {
-    private Integer code;
-    private T data;
+public class MessageResponseDTO {
     private String message;
 }

--- a/src/main/java/org/jungle/code_post/post/controller/PostController.java
+++ b/src/main/java/org/jungle/code_post/post/controller/PostController.java
@@ -1,7 +1,9 @@
 package org.jungle.code_post.post.controller;
 
 import lombok.extern.slf4j.Slf4j;
+import org.jungle.code_post.common.dto.MessageResponseDTO;
 import org.jungle.code_post.post.dto.PostCreateRequestDTO;
+import org.jungle.code_post.post.dto.PostDeleteRequestDTO;
 import org.jungle.code_post.post.dto.PostResponseDTO;
 import org.jungle.code_post.post.dto.PostUpdateRequestDTO;
 import org.jungle.code_post.post.service.PostService;
@@ -36,6 +38,12 @@ public class PostController {
     @PutMapping("/{id}")
     public PostResponseDTO updatePost(@PathVariable Long id, @RequestBody PostUpdateRequestDTO requestDTO){
         return postService.updatePost(id,requestDTO.toVO());
+    }
+
+
+    @DeleteMapping("/{id}")
+    public MessageResponseDTO deletePost(@PathVariable Long id, @RequestBody PostDeleteRequestDTO requestDTO){
+        return postService.deletePost(id,requestDTO.toVO());
     }
 
 }

--- a/src/main/java/org/jungle/code_post/post/dto/PostDeleteRequestDTO.java
+++ b/src/main/java/org/jungle/code_post/post/dto/PostDeleteRequestDTO.java
@@ -1,0 +1,18 @@
+package org.jungle.code_post.post.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostDeleteRequestDTO {
+    private Integer password;
+
+    public PostVO toVO(){
+        return PostVO.builder()
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/post/service/PostService.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostService.java
@@ -1,5 +1,6 @@
 package org.jungle.code_post.post.service;
 
+import org.jungle.code_post.common.dto.MessageResponseDTO;
 import org.jungle.code_post.post.dto.PostResponseDTO;
 import org.jungle.code_post.post.dto.PostVO;
 import org.springframework.stereotype.Service;
@@ -15,4 +16,7 @@ public interface PostService {
     public PostResponseDTO insertPost(PostVO postVo);
 
     public PostResponseDTO updatePost(Long id,PostVO postVO);
+
+    public MessageResponseDTO deletePost(Long id,PostVO postVO);
+
 }

--- a/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
+++ b/src/main/java/org/jungle/code_post/post/service/PostServiceNoAuth.java
@@ -1,5 +1,6 @@
 package org.jungle.code_post.post.service;
 
+import org.jungle.code_post.common.dto.MessageResponseDTO;
 import org.jungle.code_post.post.dto.PostResponseDTO;
 import org.jungle.code_post.post.dto.PostVO;
 import org.jungle.code_post.post.entity.Post;
@@ -53,5 +54,16 @@ public class PostServiceNoAuth implements PostService {
         post.setScore(postVO.getScore());
 
         return PostResponseDTO.of(postRepository.save(post));
+    }
+
+    @Override
+    public MessageResponseDTO deletePost(Long id,PostVO postVO) {
+        Optional<Post> findPost = postRepository.findById(id);
+        if (findPost.isEmpty())
+            return new MessageResponseDTO("Post not found.");
+        if (findPost.get().getPassword() != postVO.getPassword())
+            return new MessageResponseDTO("Password not matched");
+        postRepository.delete(findPost.get());
+        return new MessageResponseDTO("delete success!");
     }
 }


### PR DESCRIPTION
> Closes #9

## 작업내용
### 게시물 삭제 API 구현
- `PostController`: `/api/post/{1}` **DELETE** 매핑
- `PostService`:  `id`에 해당하는 게시물을 삭제하고 결과를 반환하는 `deletePost` 구현