### PR TITLE
#15 멤버 생성 API 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,16 +22,27 @@ repositories {
 }
 
 dependencies {
+	// JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+	// mysql connector
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	// spring web
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// spring validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	// lombok
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/org/jungle/code_post/config/SecurityConfig.java
+++ b/src/main/java/org/jungle/code_post/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package org.jungle.code_post.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http.csrf(CsrfConfigurer::disable);
+        http.cors(Customizer.withDefaults());
+
+        http.sessionManagement((sm)->sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.formLogin(FormLoginConfigurer::disable);
+        http.httpBasic(HttpBasicConfigurer::disable);
+
+        http.authorizeHttpRequests((auth)-> auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/member/controller/MemberController.java
+++ b/src/main/java/org/jungle/code_post/member/controller/MemberController.java
@@ -1,0 +1,23 @@
+package org.jungle.code_post.member.controller;
+
+import org.jungle.code_post.common.dto.MessageResponseDTO;
+import org.jungle.code_post.member.dto.AuthSignupRequestDTO;
+import org.jungle.code_post.member.service.MemberService;
+import org.jungle.code_post.member.service.MemberserviceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class MemberController {
+    @Autowired
+    private MemberService memberService = new MemberserviceImpl();
+
+    @PostMapping("/signup")
+    public MessageResponseDTO signup(@RequestBody AuthSignupRequestDTO requestDTO){
+        return memberService.insertMember(requestDTO.toVO());
+    }
+}

--- a/src/main/java/org/jungle/code_post/member/dto/AuthSignupRequestDTO.java
+++ b/src/main/java/org/jungle/code_post/member/dto/AuthSignupRequestDTO.java
@@ -1,0 +1,20 @@
+package org.jungle.code_post.member.dto;
+
+import lombok.*;
+import org.jungle.code_post.post.dto.PostVO;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthSignupRequestDTO {
+    private String username;
+    private String password;
+    public MemberVO toVO(){
+        return MemberVO.builder()
+                .username(username)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/member/dto/MemberVO.java
+++ b/src/main/java/org/jungle/code_post/member/dto/MemberVO.java
@@ -1,0 +1,35 @@
+package org.jungle.code_post.member.dto;
+
+import lombok.*;
+import org.jungle.code_post.member.entity.Member;
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberVO {
+    private String id;
+
+    private String username;
+
+    private String password;
+
+    private Member.MemberRole role = Member.MemberRole.MEMBER_ROLE_USER;
+
+    public static MemberVO from(Member member){
+        return MemberVO.builder()
+                .id(member.getId())
+                .username(member.getUsername())
+                .password(member.getPassword())
+                .role(member.getRole())
+                .build();
+    }
+
+    public Member toEntity(){
+        return Member.builder()
+                .id(id)
+                .username(username)
+                .password(password)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/member/repository/MemberRepository.java
+++ b/src/main/java/org/jungle/code_post/member/repository/MemberRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, String> {
     public Optional<Member> findByUsername(String username);
+    public boolean existsByUsername(String username);
 }

--- a/src/main/java/org/jungle/code_post/member/service/MemberService.java
+++ b/src/main/java/org/jungle/code_post/member/service/MemberService.java
@@ -1,0 +1,10 @@
+package org.jungle.code_post.member.service;
+
+import org.jungle.code_post.common.dto.MessageResponseDTO;
+import org.jungle.code_post.member.dto.MemberVO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface MemberService {
+    public MessageResponseDTO insertMember(MemberVO memberVO);
+}

--- a/src/main/java/org/jungle/code_post/member/service/MemberserviceImpl.java
+++ b/src/main/java/org/jungle/code_post/member/service/MemberserviceImpl.java
@@ -1,0 +1,28 @@
+package org.jungle.code_post.member.service;
+
+import org.jungle.code_post.common.dto.MessageResponseDTO;
+import org.jungle.code_post.member.dto.MemberVO;
+import org.jungle.code_post.member.entity.Member;
+import org.jungle.code_post.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberserviceImpl implements MemberService {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Override
+    public MessageResponseDTO insertMember(MemberVO memberVO) {
+        if(memberRepository.existsByUsername(memberVO.getUsername()))
+            return new MessageResponseDTO("duplicate username");
+        Member member = memberVO.toEntity();
+        member.setPassword(passwordEncoder.encode(member.getPassword()));
+        memberRepository.save(member);
+        return new MessageResponseDTO("signup success");
+    }
+}


### PR DESCRIPTION
> Closes #15

## 작업내용

### DTO,VO 구현
- `AuthSignipRequestDTO` : 멤버 등록 요청 시 해당 객체에 저장됨
- `MemberVO` : 컨트롤러 <-> 서비스 계층 간 데이터 교환 객체

### PostController,PostService 구현
- `PostController` : `/api/auth/signup` **POST** 매핑
- `PostService` : `insertMember` 구현
    - 비밀번호 암호화

### Spring security 설정
- `SecurityConfig` : jwt를 위한 설정 및 passwordEncorder`추가