### PR TITLE
#17 로그인 API 구현 완료

### DIFF
--- a/src/main/java/org/jungle/code_post/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/jungle/code_post/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,56 @@
+package org.jungle.code_post.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.jungle.code_post.member.dto.MemberInfoDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@Slf4j
+public class JwtTokenProvider {
+    public static final String BEARER_TYPE = "Bearer";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String REFRESH_HEADER = "Refresh";
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expiration-time}")
+    private long accessTokenExpirationTime;
+
+    private Key key;
+
+    @PostConstruct
+    public void init(){
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(MemberInfoDTO memberInfoDTO){
+        long now = new Date(System.currentTimeMillis()).getTime();
+
+
+        Claims claims = Jwts.claims();
+                claims.put("username",memberInfoDTO.getUsername());
+                claims.put("role",memberInfoDTO.getRole());
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + accessTokenExpirationTime))
+                .signWith(key,SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+}

--- a/src/main/java/org/jungle/code_post/member/controller/MemberController.java
+++ b/src/main/java/org/jungle/code_post/member/controller/MemberController.java
@@ -1,7 +1,11 @@
 package org.jungle.code_post.member.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
+import org.jungle.code_post.auth.jwt.JwtTokenProvider;
 import org.jungle.code_post.common.dto.MessageResponseDTO;
+import org.jungle.code_post.member.dto.AuthLoginRequestDTO;
 import org.jungle.code_post.member.dto.AuthSignupRequestDTO;
+import org.jungle.code_post.member.dto.MemberInfoDTO;
 import org.jungle.code_post.member.service.MemberService;
 import org.jungle.code_post.member.service.MemberserviceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,9 +19,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     @Autowired
     private MemberService memberService = new MemberserviceImpl();
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider = new JwtTokenProvider();
 
     @PostMapping("/signup")
-    public MessageResponseDTO signup(@RequestBody AuthSignupRequestDTO requestDTO){
+    public MessageResponseDTO signup(@RequestBody AuthSignupRequestDTO requestDTO) {
         return memberService.insertMember(requestDTO.toVO());
+    }
+
+    @PostMapping("/login")
+    public MessageResponseDTO login(@RequestBody AuthLoginRequestDTO requestDTO, HttpServletResponse response) {
+        MemberInfoDTO member = memberService.findMemberByUsername(requestDTO.toVO());
+        if (member == null)
+            return new MessageResponseDTO("login failed");
+        response.setHeader(JwtTokenProvider.AUTHORIZATION_HEADER, JwtTokenProvider.BEARER_PREFIX + jwtTokenProvider.generateToken(member));
+        return new MessageResponseDTO("login success");
     }
 }

--- a/src/main/java/org/jungle/code_post/member/dto/AuthLoginRequestDTO.java
+++ b/src/main/java/org/jungle/code_post/member/dto/AuthLoginRequestDTO.java
@@ -1,0 +1,19 @@
+package org.jungle.code_post.member.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthLoginRequestDTO {
+    private String username;
+    private String password;
+    public MemberVO toVO(){
+        return MemberVO.builder()
+                .username(username)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/member/dto/MemberInfoDTO.java
+++ b/src/main/java/org/jungle/code_post/member/dto/MemberInfoDTO.java
@@ -1,0 +1,17 @@
+package org.jungle.code_post.member.dto;
+
+import lombok.*;
+import org.jungle.code_post.member.entity.Member;
+
+@Builder
+@Data
+public class MemberInfoDTO {
+    private final String username;
+    private final Member.MemberRole role;
+    public static MemberInfoDTO of(Member member){
+        return MemberInfoDTO.builder()
+                .username(member.getUsername())
+                .role(member.getRole())
+                .build();
+    }
+}

--- a/src/main/java/org/jungle/code_post/member/entity/Member.java
+++ b/src/main/java/org/jungle/code_post/member/entity/Member.java
@@ -2,6 +2,7 @@ package org.jungle.code_post.member.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DialectOverride;
 import org.jungle.code_post.common.entity.BaseTimestampEntity;
 
@@ -23,8 +24,9 @@ public class Member extends BaseTimestampEntity {
     @Column(nullable = false)
     private String password;
 
-    @Builder.Default
-    private MemberRole role = MemberRole.MEMBER_ROLE_USER;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
 
     public enum MemberRole{
         MEMBER_ROLE_ADMIN

--- a/src/main/java/org/jungle/code_post/member/service/MemberService.java
+++ b/src/main/java/org/jungle/code_post/member/service/MemberService.java
@@ -1,10 +1,12 @@
 package org.jungle.code_post.member.service;
 
 import org.jungle.code_post.common.dto.MessageResponseDTO;
+import org.jungle.code_post.member.dto.MemberInfoDTO;
 import org.jungle.code_post.member.dto.MemberVO;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface MemberService {
     public MessageResponseDTO insertMember(MemberVO memberVO);
+    public MemberInfoDTO findMemberByUsername(MemberVO memberVO);
 }

--- a/src/main/java/org/jungle/code_post/member/service/MemberserviceImpl.java
+++ b/src/main/java/org/jungle/code_post/member/service/MemberserviceImpl.java
@@ -1,6 +1,8 @@
 package org.jungle.code_post.member.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.jungle.code_post.common.dto.MessageResponseDTO;
+import org.jungle.code_post.member.dto.MemberInfoDTO;
 import org.jungle.code_post.member.dto.MemberVO;
 import org.jungle.code_post.member.entity.Member;
 import org.jungle.code_post.member.repository.MemberRepository;
@@ -8,7 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
+@Slf4j
 public class MemberserviceImpl implements MemberService {
     @Autowired
     private MemberRepository memberRepository;
@@ -22,7 +27,24 @@ public class MemberserviceImpl implements MemberService {
             return new MessageResponseDTO("duplicate username");
         Member member = memberVO.toEntity();
         member.setPassword(passwordEncoder.encode(member.getPassword()));
+        member.setRole(Member.MemberRole.MEMBER_ROLE_USER);
         memberRepository.save(member);
         return new MessageResponseDTO("signup success");
+    }
+
+    @Override
+    public MemberInfoDTO findMemberByUsername(MemberVO memberVO) {
+        Optional<Member> findMember = memberRepository.findByUsername(memberVO.getUsername());
+        if(findMember.isEmpty()) {
+            log.debug("empty member");
+            return null;
+        }
+        Member member = findMember.get();
+        if(!passwordEncoder.matches(memberVO.getPassword(),member.getPassword())) {
+            log.debug("incorrect password");
+            return null;
+        }
+        log.debug(member.toString());
+        return MemberInfoDTO.of(member);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,6 @@ jwt:
 
 logging:
   level:
-    root : debug
+    org.jungle.code_post : debug
     org.hibernate.SQL: debug
     org.hibernate.type: trace

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,12 @@ spring:
       hibernate:
         format_sql: true
 
+jwt:
+  access-token-expiration-time: 86400000
+  secret: 2f2cbcfb5955e9f2ae796ee0988c3dbe15fb5446dc51df1f0244432b966b79de
+
 logging:
   level:
+    root : debug
     org.hibernate.SQL: debug
     org.hibernate.type: trace


### PR DESCRIPTION
> Closes #17 

## 작업내용

### DTO 구현

- `AuthLoginRequestDTO` : 로그인 요청 시 해당 객체를 통해 전달
- `MemberInfoDTO` : JWT 토큰 생성을 위한 전달 객체

### 로그인 API 구현
- `MemberController` : `/api/auth/login` **POST** 매핑
    - 로그인 성공 시 JWT토큰을 생성하여 헤더에 담아 반환 
- `MemberService` : `findMemberByUsername` 구현
    - 로그인 성공 시 해당 멤버의 `MemberInfoDTO` 반환
    
### JWT 토큰 생성 
- `JwtTokenProvider` : JWT 토큰 생성자
- `application.yml` : 토큰 생성에 필요한 `secret key` 및 만료시간 추가


